### PR TITLE
fix: ensure weapon index is within valid 16-bit range

### DIFF
--- a/PyItV1.0.6.py
+++ b/PyItV1.0.6.py
@@ -604,6 +604,8 @@ def esp(scene, pm, client, offsets, client_dll, window_width, window_height, set
             return
 
 def get_weapon_name_by_index(index):
+    index = index & 0xFFFF
+    
     weapon_names = {
     32: "P2000",
     61: "USP-S",
@@ -632,7 +634,7 @@ def get_weapon_name_by_index(index):
     16: "M4A4",
     60: "M4A1-S",
     8: "AUG",
-    43: "Galil",
+    13: "Galil",
     7: "AK-47",
     39: "SG 553",
     40: "SSG 08",


### PR DESCRIPTION
Added a bitwise AND operation (`index = index & 0xFFFF`) at the beginning of the `get_weapon_name_by_index` function to ensure that the input index is always within the valid 16-bit range. This prevents issues caused by negative or out-of-range values that could result from unsigned-to-signed integer conversions or memory reading anomalies.

This change helps improve reliability when integrating with game memory structures where weapon indices may contain additional flags or unintended bits.

Also noticed a key duplication for index 43 ("Galil" and "Flashbang"). Only the last entry will be used due to dictionary behavior. 